### PR TITLE
#102 순환노선 손잡이 안 보이던 버그

### DIFF
--- a/Assets/Scripts/Line/Line.cs
+++ b/Assets/Scripts/Line/Line.cs
@@ -92,8 +92,8 @@ public class Line : MonoBehaviour
         Vector3 dirEnd;
         if (isCircular)
         {
-            dirEnd = (waypoints[0] - waypoints[^1]).normalized;
-            handleEnd.transform.position = stations[0].transform.position;
+            dirEnd = (waypoints[0] - waypoints[^2]).normalized;
+            handleEnd.transform.position = handleStart.transform.position;
         }
         else
         {


### PR DESCRIPTION
wapoints[^1] == waypoints[0] 이었던 것이다. . .