### PR TITLE
fix: 열차 무정차 통과 및 길찾기 버그 수정 (#59)

### DIFF
--- a/Assets/Scripts/TrainPassenger/Train.cs
+++ b/Assets/Scripts/TrainPassenger/Train.cs
@@ -211,11 +211,14 @@ public class Train : MonoBehaviour
 
         bool isNextAStation = isStationWaypoint(waypointTargetIndex);
         Station nextStation = isNextAStation ? GetStationAtWaypoint(waypointTargetIndex) : null;
+        int nextStationIndex = isNextAStation ? waypointTargetIndex / 2 : -1;
         //감속 판정 - 이번 역이 종점 이거나 정차해야 하는 역이면 감속 준비
         bool shouldStopHere =
             isNextAStation
             && nextStation != null
-            && (IsTerminalStation(nextStation) || ShouldStopAtStation(nextStation));
+            && (
+                IsTerminalStation(nextStation) || ShouldStopAtStation(nextStation, nextStationIndex)
+            );
 
         float currentSpeed = maxSpeed;
         //속도 조절 로직. 느리게 출발해서 중간부분은 최고속도 유지하고 도착할때쯤에는 다시 느리게 이동
@@ -289,7 +292,7 @@ public class Train : MonoBehaviour
             }
             else
             {
-                AdvanceWaypoint();
+                AdvanceWaypoint(resetStartPos: false);
             }
         }
 
@@ -301,9 +304,10 @@ public class Train : MonoBehaviour
     }
 
     // waypoint 인덱스 진행 (방향 포함)
-    public void AdvanceWaypoint()
+    public void AdvanceWaypoint(bool resetStartPos = true)
     {
-        startPos = transform.position;
+        if (resetStartPos)
+            startPos = transform.position;
         bool isCircularLine = (myLine != null) && myLine.isCircular;
         // 방향에 따라 다음 타겟 waypoint 결정
         if (direction == TrainDirection.Forward)
@@ -544,18 +548,23 @@ public class Train : MonoBehaviour
         return int.MaxValue;
     }
 
-    public bool CanBoard(Passenger p)
+    public bool CanBoard(Passenger p, int boardingIndex = -1)
     {
         if (p.blockedLineId == lineId)
             return false;
 
+        int idx = boardingIndex >= 0 ? boardingIndex : targetStationIndex;
+
         if (myLine != null && myLine.isCircular)
         {
-            return BFSDistance(p.destination, targetStationIndex, 1) != int.MaxValue;
+            int nextIdx = (idx + 1) % path.Count;
+            return BFSDistance(p.destination, nextIdx, 1) != int.MaxValue;
         }
 
         var dir = direction == TrainDirection.Forward ? 1 : -1;
-        int nextIndex = Mathf.Clamp(targetStationIndex + dir, 0, path.Count - 1);
+        int nextIndex = idx + dir;
+        if (nextIndex < 0 || nextIndex >= path.Count)
+            return false;
         int myDist = BFSDistance(p.destination, nextIndex, dir);
 
         return myDist != int.MaxValue;
@@ -619,17 +628,20 @@ public class Train : MonoBehaviour
     }
 
     // 현재 역에 정차 해야하는지 검사
-    private bool ShouldStopAtStation(Station station)
+    private bool ShouldStopAtStation(Station station, int stationIndex)
     {
         foreach (var p in passengers)
         {
-            if (p.destination == station.Shape)
+            if (p.destination == station.Shape || p.transferStation == station)
                 return true;
         }
-        foreach (var p in station.waitingPassengers)
+        if (passengers.Count < capacity)
         {
-            if (CanBoard(p))
-                return true;
+            foreach (var p in station.waitingPassengers)
+            {
+                if (CanBoard(p, stationIndex))
+                    return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## 수정 내용

- **무정차 역 가속/감속 버그** (`AdvanceWaypoint`): 무정차 역 통과 시 `startPos`를 갱신하지 않도록 수정. 기존에는 통과할 때마다 `traveledDistance`가 0으로 리셋되어 가속 페이즈가 반복됐으나, 이제 정차역 출발 후 누적 거리를 유지해 최고 속도를 안정적으로 유지함.

- **환승 승객 무정차 통과 버그** (`ShouldStopAtStation`): 열차에 탑승한 승객 중 환승 하차(`p.transferStation == station`) 조건을 정차 판정에 추가. 기존에는 목적지 도착 승객만 체크해 환승역에서도 무정차 통과하는 문제가 있었음.

- **길찾기 인덱스 오류** (`CanBoard`, `ShouldStopAtStation`): `targetStationIndex`(마지막 정차역 인덱스)가 무정차 역 통과 시 갱신되지 않아 `CanBoard`와 `FindTransferStation`이 잘못된 역 기준으로 BFS를 실행하는 문제 수정. `Move()`에서 `waypointTargetIndex / 2`로 실제 다음 역 인덱스를 계산해 전달하도록 변경. `CanBoard`의 Clamp 로직도 제거하고 범위 초과 시 `false` 반환으로 교체.

## 관련 이슈

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)